### PR TITLE
drop dispformula when fitting binomial model in timeMortality vignette

### DIFF
--- a/vignettes/timeMortality.Rmd
+++ b/vignettes/timeMortality.Rmd
@@ -828,10 +828,11 @@ shorten <- function(nam, leaveout=c('trtGp','Fly',':')){
 }
 ```
 
-```{r crude-cll, echo=FALSE, warning=F}
+```{r crude-cll, echo=FALSE, warning=FALSE}
 ## Fit two simplistic and unsatisfactory models.
 HCbbDisp1.cll <- update(HCbb.cll, dispformula=~1)
-HCbin.cll <- update(HCbb.cll, family=binomial(link="cloglog"))
+HCbin.cll <- update(HCbb.cll, family=binomial(link="cloglog"),
+                    dispformula = ~1)
 ```
 
 


### PR DESCRIPTION
In the vignette, a model originally fitted with beta-binomial response and a non-trivial dispersion model is updated to try a binomial response instead, without resetting the dispersion formula. This broke `vcov.glmmTMB()` because of some changes we made to `glmmTMB`; we're fixing `vcov.glmmTMB()`  not to break on a model that uses a fixed dispersion family (binomial, Poisson) with a non-trivial dispersion model,  but it probably makes sense to do this 'correctly' in the vignette.  (We might add a warning, or even an error, for this case in the future ...)